### PR TITLE
Add command to kill any running Csound subprocess.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "csound-vscode-plugin" extension will be documented i
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.2.1
+
+* Add command to kill any running Csound subprocess. Kill any Csound process on exiting from VSCode.
+
 ## 0.2.0
 
 * Implemented the ability to play the CSD file in the currently-active editor window from within VSCode.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Program currently provides:
 
 * Syntax Highlighting for Csound .orc and .udo files
 
-* Play the CSD file in the currently-active editor window by choosing `Csound: Play Active CSD Document` from the command palette or using the `Alt+.` shortcut.
+* Play the CSD file in the currently-active editor window by choosing `Csound: Play Active CSD Document` from the command palette or using the `alt+.` shortcut. To kill a playing Csound subprocess, choose `Csound: Csound: Terminate any running csound subprocess`
+from the command palette or use the `alt+escape` shortcut.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "csound-vscode-plugin",
     "displayName": "Csound",
     "description": "Csound language plugin for Visual Studio Code",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publisher": "kunstmusik",
     "engines": {
         "vscode": "^1.22.0"
@@ -19,6 +19,10 @@
             {
                 "command": "extension.csoundPlayActiveDocument",
                 "title": "Csound: Play Active CSD Document"
+            },
+            {
+                "command": "extension.csoundKillCsoundProcess",
+                "title": "Csound: Terminate any running csound subprocess"
             }
         ],
         "configuration": {
@@ -94,11 +98,17 @@
                 "path": "./syntaxes/csound-csd.tmLanguage.json"
             }
         ],
-        "keybindings": [{
-            "command": "extension.csoundPlayActiveDocument",
-            "key": "alt+.",
-            "when": "editorLangId == csound-csd && editorFocus"
-        }]
+        "keybindings": [
+            {
+                "command": "extension.csoundPlayActiveDocument",
+                "key": "alt+.",
+                "when": "editorLangId == csound-csd && editorFocus"
+            },
+            {
+                "command": "extension.csoundKillCsoundProcess",
+                "key": "alt+escape"
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/src/csoundCommands.ts
+++ b/src/csoundCommands.ts
@@ -6,7 +6,7 @@ import * as cp from 'child_process';
 import * as vscode from 'vscode';
 
 let output: vscode.OutputChannel;
-let process: cp.ChildProcess | undefined;
+const processMap: any = {};
 
 export async function playActiveDocument(textEditor: vscode.TextEditor) {
     const config = vscode.workspace.getConfiguration("csound");
@@ -29,9 +29,7 @@ export async function playActiveDocument(textEditor: vscode.TextEditor) {
     if (output === undefined) {
         output = vscode.window.createOutputChannel("Csound output");
     }
-    if (process !== undefined) {
-        killCsoundProcess();
-    }
+
     const command = config.get("executable", "csound");
     // We need to clone the args array because if we don't, when we push the filename on, it
     // will actually go into the config in memory, and be in the args of our next syntax check.
@@ -42,7 +40,10 @@ export async function playActiveDocument(textEditor: vscode.TextEditor) {
     output.clear();
     output.show();
 
-    process = cp.spawn(command, args, options);
+    const process = cp.spawn(command, args, options);
+
+    processMap[process.pid] = process;
+
     process.stdout.on('data', (data) => {
         // I've seen spurious 'ANSI reset color' sequences in some csound output
         // which doesn't render correctly in this context. Stripping that out here.
@@ -53,9 +54,8 @@ export async function playActiveDocument(textEditor: vscode.TextEditor) {
         // If you want your changes to show up, change this one.
         output.append(data.toString().replace(/\x1b\[m/g, ''));
     });
-    process.on('exit', () => { process = undefined });
     if (process.pid) {
-        console.log("Csound is playing");
+        console.log("Csound is playing (pid " + process.pid + ")");
     }
 }
 
@@ -89,8 +89,14 @@ async function setSaveSilentlyOnPlay() {
 }
 
 export function killCsoundProcess() {
-    if (process !== undefined) {
-        process.kill('SIGTERM');
-        console.log("Csound subprocess terminated");
+    for (let pid in processMap) {
+        let p = processMap[pid];
+        if (p === undefined) {
+            delete p[pid];
+        } else {
+            console.log("Killing Csound process (pid " + p.pid + ")");
+            p.kill('SIGTERM');
+            console.log("Csound subprocess terminated");
+        }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,13 @@ export function activate(context: vscode.ExtensionContext) {
         commands.playActiveDocument);
     context.subscriptions.push(playCommand);
 
+    const killCommand = vscode.commands.registerCommand(
+        'extension.csoundKillCsoundProcess',
+        commands.killCsoundProcess);
+    context.subscriptions.push(killCommand);
 }
 
 // this method is called when your extension is deactivated
 export function deactivate() {
+    commands.killCsoundProcess();
 }


### PR DESCRIPTION
Kill any running Csound subprocess before starting a new one.
Kill any running Csound subprocess on exiting VSCode.

Wait for document to save before spawning Csound subprocess to play it.

Keybinding to stop the running Csound is `alt+escape` because I couldn't find a way to restrict a keybinding to when the focus is on an output channel.