### PR TITLE
Two more small fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "Programming Languages"
     ],
     "activationEvents": [
-        "onCommand:extension.csoundPlayActiveDocument"
+        "onCommand:extension.csoundPlayActiveDocument",
+        "onCommand:extension.csoundKillCsoundProcess"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/src/csoundCommands.ts
+++ b/src/csoundCommands.ts
@@ -6,7 +6,7 @@ import * as cp from 'child_process';
 import * as vscode from 'vscode';
 
 let output: vscode.OutputChannel;
-const processMap: any = {};
+const processMap: { [pid: number]: cp.ChildProcess | undefined } = {};
 
 export async function playActiveDocument(textEditor: vscode.TextEditor) {
     const config = vscode.workspace.getConfiguration("csound");
@@ -92,7 +92,7 @@ export function killCsoundProcess() {
     for (let pid in processMap) {
         let p = processMap[pid];
         if (p === undefined) {
-            delete p[pid];
+            delete processMap[pid];
         } else {
             console.log("Killing Csound process (pid " + p.pid + ")");
             p.kill('SIGTERM');


### PR DESCRIPTION
I found the correct typescript declaration to strongly type the object I'm using to store process info. What I thought was an error in the declaration when I tried that before was actually another error in my code that strong typing found and I was able to fix.

The second error I discovered was that pressing `alt+escape` when no csound subprocess was running brought up a "command not found" warning message box. A tweak to package.json fixed this.