### PR TITLE
Don't change focus away from editor window when playing CSD file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "csound-vscode-plugin" extension will be documented i
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## 0.2.3
+
+* Playing the contents of the CSD text editor doesn't shift focus to the output window.
+* `alt+escape` to kill CSound processes only works when focus is in a CSD text editor window (to increase
+  compatibility with other modules).
+
 ## 0.2.2
 
 * Fixed to prevent error when running kill command with no Csound subprocesses.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Program currently provides:
 
 * Syntax Highlighting for Csound .orc and .udo files
 
-* Play the CSD file in the currently-active editor window by choosing `Csound: Play Active CSD Document` from the command palette or using the `alt+.` shortcut. To kill a playing Csound subprocess, choose `Csound: Terminate any running csound subprocess`
-from the command palette or use the `alt+escape` shortcut.
+* Play the CSD file in the currently-active editor window by choosing `Csound: Play Active CSD Document`
+ from the command palette or using the `alt+.` shortcut. To kill a playing Csound subprocess, choose
+ `Csound: Terminate any running csound subprocess` from the command palette or use the `alt+escape` shortcut
+ while the focus is still in a CSD text editor window.
 
 ## Requirements
 
@@ -31,7 +33,12 @@ ORC to a SCO file (or SCO to an ORC file) will need to be implemented before the
 
 ## Release Notes
 
-### 0.2.1
+### 0.2.3
+
+Don't switch focus to output window when playing a CSD file. `alt+escape` only kills CSound subprocesses when focus is in a
+CSD text editor window (for better compatibility with other modules).
+
+### 0.2.2
 
 Fix issue when attempting to kill when there are no Csound subprocesses running.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "csound-vscode-plugin",
     "displayName": "Csound",
     "description": "Csound language plugin for Visual Studio Code",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "publisher": "kunstmusik",
     "engines": {
         "vscode": "^1.22.0"
@@ -107,7 +107,8 @@
             },
             {
                 "command": "extension.csoundKillCsoundProcess",
-                "key": "alt+escape"
+                "key": "alt+escape",
+                "when": "editorLangId == csound-csd && editorFocus"
             }
         ]
     },

--- a/src/csoundCommands.ts
+++ b/src/csoundCommands.ts
@@ -38,7 +38,7 @@ export async function playActiveDocument(textEditor: vscode.TextEditor) {
     const options = { cwd: path.dirname(document.fileName) };
 
     output.clear();
-    output.show();
+    output.show(true); // true means keep focus in the editor window
 
     const process = cp.spawn(command, args, options);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
         commands.playActiveDocument);
     context.subscriptions.push(playCommand);
 
-    const killCommand = vscode.commands.registerCommand(
+    const killCommand = vscode.commands.registerTextEditorCommand(
         'extension.csoundKillCsoundProcess',
         commands.killCsoundProcess);
     context.subscriptions.push(killCommand);


### PR DESCRIPTION
Require focus to remain in CSD editor window for `alt+escape` to kill Csound subprocesses.

When I went to put the same functionality I just implemented for Csound into my ChucK extension, I realized I couldn't use `alt+escape` for both if they're global. Since I found out how to not change focus from the editor window when you play a CSD file, this change will make it so that you need to still be in a CSD window to kill Csound subprocesses with `alt+escape`. I think this should be fine, since you will still be in the editor window when you play the file.