### PR TITLE
v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Program currently provides:
 
 * Syntax Highlighting for Csound .orc and .udo files
 
-* Play the CSD file in the currently-active editor window by choosing `Csound: Play Active CSD Document`
+* Play the file in the currently-active editor window by choosing `Csound: Play Active Document`
  from the command palette or using the `alt+.` shortcut. To kill a playing Csound subprocess, choose
  `Csound: Terminate any running csound subprocess` from the command palette or use the `alt+escape` shortcut
- while the focus is still in a CSD text editor window.
+ while the focus is still in a Csound text editor window.
 
  * Evaluate code at runtime (live coding) using `Csound: Evaluate Orchestra Code` or `ctrl+enter` (`cmd+enter` on macOS) for ORC code and `Csound: Evaluate Score Code` for SCO code. 
 
@@ -32,10 +32,14 @@ You must have Csound properly configured on your system so you can use it on the
 
 ## Known Issues
 
-Currently this extension can only play CSD files from the currently-active editor window. A method of associating the appropriate
-ORC to a SCO file (or SCO to an ORC file) will need to be implemented before these are playable inside of VSCode.
+None.
 
 ## Release Notes
+
+## 0.5.0
+* Can now play from ORC/SCO pair, associating to the file from the currently-active editor window a file contained in the same folder with the same name but opposite extension.
+
+* Added CSD barebone as snippet, use the keyword `barebone` to insert the template code in your CSD file. 
 
 ## 0.4.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "csound-vscode-plugin",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "csound-vscode-plugin",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "devDependencies": {
                 "@types/glob": "^7.1.4",
                 "@types/mocha": "^9.0.0",
@@ -25,7 +25,7 @@
                 "ts-loader": "^9.2.5",
                 "typescript": "^4.4.3",
                 "webpack": "^5.52.1",
-                "webpack-cli": "^4.8.0"
+                "webpack-cli": "^4.9.0"
             },
             "engines": {
                 "vscode": "^1.60.0"
@@ -685,9 +685,9 @@
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-            "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+            "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
             "dev": true,
             "peerDependencies": {
                 "webpack": "4.x.x || 5.x.x",
@@ -695,9 +695,9 @@
             }
         },
         "node_modules/@webpack-cli/info": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-            "integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+            "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
             "dev": true,
             "dependencies": {
                 "envinfo": "^7.7.3"
@@ -707,9 +707,9 @@
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-            "integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+            "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
             "dev": true,
             "peerDependencies": {
                 "webpack-cli": "4.x.x"
@@ -1284,9 +1284,9 @@
             "dev": true
         },
         "node_modules/colorette": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-            "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+            "version": "2.0.16",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+            "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
             "dev": true
         },
         "node_modules/commander": {
@@ -5100,16 +5100,16 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-            "integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.0.tgz",
+            "integrity": "sha512-n/jZZBMzVEl4PYIBs+auy2WI0WTQ74EnJDiyD98O2JZY6IVIHJNitkYp/uTXOviIOMfgzrNvC9foKv/8o8KSZw==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.0.4",
-                "@webpack-cli/info": "^1.3.0",
-                "@webpack-cli/serve": "^1.5.2",
-                "colorette": "^1.2.1",
+                "@webpack-cli/configtest": "^1.1.0",
+                "@webpack-cli/info": "^1.4.0",
+                "@webpack-cli/serve": "^1.6.0",
+                "colorette": "^2.0.14",
                 "commander": "^7.0.0",
                 "execa": "^5.0.0",
                 "fastest-levenshtein": "^1.0.12",
@@ -5946,25 +5946,25 @@
             }
         },
         "@webpack-cli/configtest": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-            "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+            "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
             "dev": true,
             "requires": {}
         },
         "@webpack-cli/info": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-            "integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+            "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
             "dev": true,
             "requires": {
                 "envinfo": "^7.7.3"
             }
         },
         "@webpack-cli/serve": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-            "integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+            "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
             "dev": true,
             "requires": {}
         },
@@ -6377,9 +6377,9 @@
             "dev": true
         },
         "colorette": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-            "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+            "version": "2.0.16",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+            "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
             "dev": true
         },
         "commander": {
@@ -9248,16 +9248,16 @@
             }
         },
         "webpack-cli": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-            "integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.0.tgz",
+            "integrity": "sha512-n/jZZBMzVEl4PYIBs+auy2WI0WTQ74EnJDiyD98O2JZY6IVIHJNitkYp/uTXOviIOMfgzrNvC9foKv/8o8KSZw==",
             "dev": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^1.0.4",
-                "@webpack-cli/info": "^1.3.0",
-                "@webpack-cli/serve": "^1.5.2",
-                "colorette": "^1.2.1",
+                "@webpack-cli/configtest": "^1.1.0",
+                "@webpack-cli/info": "^1.4.0",
+                "@webpack-cli/serve": "^1.6.0",
+                "colorette": "^2.0.14",
                 "commander": "^7.0.0",
                 "execa": "^5.0.0",
                 "fastest-levenshtein": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "csound-vscode-plugin",
     "displayName": "Csound",
     "description": "Csound language plugin for Visual Studio Code",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "publisher": "kunstmusik",
     "engines": {
         "vscode": "^1.60.0"
@@ -22,7 +22,7 @@
         "commands": [
             {
                 "command": "extension.csoundPlayActiveDocument",
-                "title": "Csound: Play Active CSD Document"
+                "title": "Csound: Play Active Document"
             },
             {
                 "command": "extension.csoundKillCsoundProcess",
@@ -126,18 +126,24 @@
             {
                 "command": "extension.csoundPlayActiveDocument",
                 "key": "alt+.",
-                "when": "editorLangId == csound-csd && editorFocus"
+                "when": "editorFocus"
             },
             {
                 "command": "extension.csoundKillCsoundProcess",
                 "key": "alt+escape",
-                "when": "editorLangId == csound-csd && editorFocus"
+                "when": "editorFocus"
             },
             {
                 "command": "extension.csoundEvalOrc",
                 "key": "ctrl+enter",
                 "mac": "cmd+enter",
                 "when": "editorTextFocus"
+            }
+        ],
+        "snippets": [
+            {
+                "language": "csound-csd",
+                "path": "./snippets/csd-snippets.json"
             }
         ]
     },
@@ -162,15 +168,15 @@
         "@typescript-eslint/parser": "^4.31.1",
         "@vscode/test-electron": "^1.6.2",
         "@vscode/test-web": "^0.0.8",
-		"assert": "^2.0.0",
+        "assert": "^2.0.0",
         "eslint": "^7.32.0",
         "glob": "^7.1.7",
         "mocha": "^9.1.1",
-		"process": "^0.11.10",
+        "process": "^0.11.10",
         "ts-loader": "^9.2.5",
         "typescript": "^4.4.3",
         "webpack": "^5.52.1",
-        "webpack-cli": "^4.8.0"
+        "webpack-cli": "^4.9.0"
     },
     "repository": {
         "type": "git",

--- a/snippets/csd-snippets.json
+++ b/snippets/csd-snippets.json
@@ -1,0 +1,28 @@
+{
+    "barebone": {
+        "prefix": "barebone",
+        "body": [
+          "<CsoundSynthesizer>",
+          ";all code relating to Csound should be encapsulated between",
+          ";<CsoundSynthesizer> and </CsoundSynthesizer>",
+          "    <CsOptions>",
+          "        ;this section tells Csound how to interact",
+          "        ;with various devices and hardware",
+          "        ",
+          "    </CsOptions>",
+          "",
+          "    <CsInstruments>",
+          "        ;this section contains instrument definitions",
+          "        ",
+          "    </CsInstruments>",
+          "",
+          "    <CsScore>",
+          "        ;this section tells Csound when and how to perform instruments",
+          "        ;defined in the CsInstruments section above.",
+          "        ",
+          "    </CsScore>",
+          "</CsoundSynthesizer>"
+        ],
+        "description": "Csound .csd file barebone"
+      }
+}


### PR DESCRIPTION
- Can now play from ORC/SCO pair, associating to the file from the currently-active editor window a file contained in the same folder with the same name but opposite extension.
- Added CSD barebone as snippet, use the keyword _barebone_ to insert the template code in your CSD file. 