### PR TITLE
Add VSCode Formatting Ability

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "onCommand:extension.csoundPlayActiveDocument",
         "onCommand:extension.csoundKillCsoundProcess",
         "onCommand:extension.csoundEvalOrc",
-        "onCommand:extension.csoundEvalSco"
+        "onCommand:extension.csoundEvalSco",
+        "onLanguage:csound-csd"
     ],
     "main": "./dist/extension.js",
     "browser": "./dist/web/extension.js",
@@ -138,6 +139,12 @@
                 "key": "ctrl+enter",
                 "mac": "cmd+enter",
                 "when": "editorTextFocus"
+            },
+            {
+                "command": "extension.csoundFormat",
+                "key": "ctrl+shift+i",
+                "mac": "cmd+shift+i",
+                "when": "editorFocus"
             }
         ],
         "snippets": [

--- a/src/csoundCommands.ts
+++ b/src/csoundCommands.ts
@@ -142,3 +142,10 @@ export async function evalSco(textEditor: vscode.TextEditor) {
     socket.send("$" + text, port, address);
     flash(textEditor, new vscode.Range(from, to));
 }
+
+export class GoDocumentFormatter implements vscode.DocumentFormattingEditProvider {
+    public provideDocumentFormattingEdits(document: vscode.TextDocument):
+        Thenable<vscode.TextEdit[]> {
+            return Promise.resolve([]);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,8 @@ import * as vscode from 'vscode';
 
 import * as commands from './csoundCommands';
 
+const fullRange = (doc: vscode.TextDocument) => doc.validateRange(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(Number.MAX_VALUE, Number.MAX_VALUE)));
+
 export function activate(context: vscode.ExtensionContext) {
 
     // play command
@@ -26,6 +28,21 @@ export function activate(context: vscode.ExtensionContext) {
         'extension.csoundEvalSco',
         commands.evalSco);
     context.subscriptions.push(evalScoCommand);
+
+    vscode.languages.registerDocumentFormattingEditProvider('csound-csd', {
+        provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
+            let text = document.getText();
+            // Replace all commas without a following space or with more than one with a single space
+            text = text.replace(/(,(?![ ])|,[ ]{2,})/g, ', ');
+            // Replace all space before instr headers with a single tab
+            text = text.replace(/[ ]{0,}instr/g, '\tinstr');
+            // Replace all space before instr footers with a single tab
+            text = text.replace(/[ ]{0,}endin/g, '\endin');
+            return [vscode.TextEdit.replace(fullRange(document), text)];
+        }
+    });
+
+    
 }
 
 // this method is called when your extension is deactivated

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -9,6 +9,15 @@ export function activate(context: vscode.ExtensionContext) {
 	const notYetImplementedForWeb = () => {
 		vscode.window.showInformationMessage("This command has not yet been reimplemented for the web.");
 	};
+
+    class GoDocumentFormatter implements vscode.DocumentFormattingEditProvider {
+        public provideDocumentFormattingEdits(document: vscode.TextDocument):
+            Thenable<vscode.TextEdit[]> {
+        return Promise.resolve([]);
+        }
+    }
+    
+
     // play command
     const playCommand = vscode.commands.registerTextEditorCommand(
         'extension.csoundPlayActiveDocument', notYetImplementedForWeb
@@ -29,6 +38,11 @@ export function activate(context: vscode.ExtensionContext) {
         'extension.csoundEvalSco',
         notYetImplementedForWeb);
     context.subscriptions.push(evalScoCommand);
+
+    const formatCommand = vscode.languages.registerDocumentFormattingEditProvider(
+        'extension.csoundFormat', new GoDocumentFormatter());
+
+    context.subscriptions.push(formatCommand);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
- [X] Initialise VSCode formatting ability
- [ ] Add format-on-save
- [ ] Tests
Add regex to support following changes:
- [ ] Spacing between args in the score
- [x] Spacing between args in the score instrs
- [ ] Align tabs in rows of opcodes
- [ ] Spacing between constants/flags