### PR TITLE
Update license to adhere to nwhetsell/language-csound license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
 MIT License
 
+Copyright (c) Nathan Whetsell and other contributors
+
 Copyright (c) 2018 Csound
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Since a substantial portion of this package (specifically, the grammars) is based on https://github.com/nwhetsell/language-csound (see for example e2c9c3893743e439043e4f7cfc457ee34f347fe4), I would ask Csound’s maintainers to adhere to its [license](https://github.com/nwhetsell/language-csound/blob/975436138f2ab808e4a2c3897586ccb0b3c958c2/LICENSE.md) by including the copyright notice.